### PR TITLE
Improve websocket reconnection handling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,15 +1,27 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from .ws_client import CentauriWebSocketClient
-from .const import DOMAIN
+from .const import DOMAIN, CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY
 
 async def async_setup(hass: HomeAssistant, config: dict):
     return True
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
-    ws_client = CentauriWebSocketClient(hass, entry.data["ip"])
+    ws_client = CentauriWebSocketClient(
+        hass,
+        entry.data["ip"],
+        retry_delay=entry.data.get(CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY),
+    )
     hass.data[DOMAIN] = ws_client
     hass.loop.create_task(ws_client.connect())
+
+    entry.async_on_unload(
+        hass.bus.async_listen_once(
+            EVENT_HOMEASSISTANT_STOP,
+            lambda event: hass.async_create_task(ws_client.async_close())
+        )
+    )
 
     await hass.config_entries.async_forward_entry_setups(
         entry, ["sensor", "camera", "fan", "light", "number", "select"]

--- a/config_flow.py
+++ b/config_flow.py
@@ -1,6 +1,11 @@
 from homeassistant import config_entries
 import voluptuous as vol
-from .const import DOMAIN, CONF_IP
+from .const import (
+    DOMAIN,
+    CONF_IP,
+    CONF_RETRY_DELAY,
+    DEFAULT_RETRY_DELAY,
+)
 
 @config_entries.HANDLERS.register(DOMAIN)
 class CentauriCarbonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -11,13 +16,15 @@ class CentauriCarbonConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             return self.async_create_entry(title="Centauri Carbon", data={
-                CONF_IP: user_input[CONF_IP]
+                CONF_IP: user_input[CONF_IP],
+                CONF_RETRY_DELAY: user_input.get(CONF_RETRY_DELAY, DEFAULT_RETRY_DELAY),
             })
 
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({
-                vol.Required(CONF_IP): str
+                vol.Required(CONF_IP): str,
+                vol.Optional(CONF_RETRY_DELAY, default=DEFAULT_RETRY_DELAY): int,
             }),
             errors=errors
         )

--- a/const.py
+++ b/const.py
@@ -1,2 +1,4 @@
 DOMAIN = "centauri_carbon"
 CONF_IP = "ip"
+CONF_RETRY_DELAY = "retry_delay"
+DEFAULT_RETRY_DELAY = 5


### PR DESCRIPTION
## Summary
- reconnect to Centauri websocket if the connection drops
- add graceful shutdown on HA stop
- allow configuring the retry delay

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eb51a7638832182cc5d9272a48ac7