### PR TITLE
Fix websocket reconnect at startup

### DIFF
--- a/custom_components/centauri_carbon/__init__.py
+++ b/custom_components/centauri_carbon/__init__.py
@@ -1,4 +1,5 @@
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import HomeAssistant
 from .ws_client import CentauriWebSocketClient
 from .const import DOMAIN
@@ -9,7 +10,14 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     ws_client = CentauriWebSocketClient(hass, entry.data["ip"])
     hass.data[DOMAIN] = ws_client
-    hass.loop.create_task(ws_client.connect())
+
+    def start_ws(event=None):
+        hass.loop.create_task(ws_client.connect())
+
+    if hass.is_running:
+        start_ws()
+    else:
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, start_ws)
 
     await hass.config_entries.async_forward_entry_setups(
         entry, ["sensor", "camera", "fan", "light", "number", "select"]


### PR DESCRIPTION
## Summary
- ensure websocket client waits for Home Assistant startup before connecting

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ec8b3238832192fc78003469420c